### PR TITLE
Pr/support number type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+## Setup
+ - Fork & Clone the project
+ - Make sure the tests compile and pass. If you get `SyntaxError: Cannot use import statement outside a module` :
+	 - Add `"type": "module"` to the nearest parent `package.json`
+	 - Replace `import {expect} from 'chai';` with `import pkg from 'chai'; const { expect } = pkg;`
+
+## Issues
+Issues are very valuable to this project.
+
+ - Ideas are a valuable source of contributions others can make
+ - Problems show where this project is lacking
+ - With a question you show where contributors can improve the user experience
+
+Thank you for creating them.

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,14 @@ export const specFor = {
             examples: [data]
         };
     },
+    'number': function (data) {
+        return {
+            title: 'A number value',
+            description: '',
+            default: 0,
+            examples: [data]
+        };
+    },
     'string': function (data) {
         return {
             title: 'A string value',

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('infer', function () {
         });
     });
     it('should infer simple object', function () {
-        expect(infer({name: 'harttle', age: 16}, {title: 'Harttle Schema'}))
+        expect(infer({name: 'harttle', age: 16, heightInMeters: 1.67}, {title: 'Harttle Schema'}))
         .to.deep.equal({
             $schema: 'http://json-schema.org/draft-07/schema#',
             $id: 'http://example.org/root.json#',
@@ -29,7 +29,7 @@ describe('infer', function () {
             type: 'object',
             title: 'Harttle Schema',
             description: '',
-            required: ['name', 'age'],
+            required: ['name', 'age', 'heightInMeters'],
             properties: {
                 name: {
                     $id: '#/properties/name',
@@ -47,6 +47,14 @@ describe('infer', function () {
                     description: '',
                     default: 0,
                     examples: [16]
+                },
+                heightInMeters: {
+                    $id: '#/properties/heightInMeters',
+                    type: 'number',
+                    title: 'A number value',
+                    description: '',
+                    default: 0,
+                    examples: [1.67]
                 }
             }
         });
@@ -73,6 +81,16 @@ describe('spec', function () {
             default: '',
             pattern: '^(.*)$',
             examples: ['harttle']
+        });
+    });
+    it('should spec number', function () {
+        expect(spec(1.67, {$id: '#/height'})).to.deep.equal({
+            $id: '#/height',
+            type: 'number',
+            title: 'A number value',
+            description: '',
+            default: 0,
+            examples: [1.67]
         });
     });
     it('should spec array', function () {


### PR DESCRIPTION
fixes #2 : add support for 'number' types (e.g., -4.5, 1.67)
previously, schema generation would crash over number types. It now works without crashing (see attached tests)

@harttle  tagging you here because the "Assign Reviewer" option is disabled for me