### PR TITLE
add: specFor null (as object)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export const specFor = {
     'object': function (data, {$id, title}) {
-        let keys = Object.keys(data);
+        let keys = Object.keys(data || {});
         let schema = {
             title: title || 'An object value',
             description: '',

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 import {typeOf, infer, spec} from '../src/index.js';
-// import {expect} from 'chai';
-import pkg from 'chai'; const { expect } = pkg;
+import {expect} from 'chai';
 
 describe('typeOf', function () {
     it('should detect boolean', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,44 @@ describe('infer', function () {
             }
         });
     });
+    it('should infer object ', function () {
+        expect(infer({name: 'harttle', age: 16, hobbies: null}, {title: 'Harttle Schema'})).to.deep.equal({
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            $id: 'http://example.org/root.json#',
+            definitions: {},
+            type: 'object',
+            title: 'Harttle Schema',
+            description: '',
+            required: ['name', 'age', 'hobbies'],
+            properties: {
+                name: {
+                    $id: '#/properties/name',
+                    type: 'string',
+                    title: 'A string value',
+                    description: '',
+                    pattern: '^(.*)$',
+                    examples: ['harttle'],
+                    default: ''
+                },
+                age: {
+                    $id: '#/properties/age',
+                    type: 'integer',
+                    title: 'An integer value',
+                    description: '',
+                    default: 0,
+                    examples: [16]
+                },
+                hobbies: {
+                    $id: '#/properties/hobbies',
+                    type: 'object',
+                    title: 'An object value',
+                    description: '',
+                    required: [],
+                    properties: {}
+                }
+            }
+        });
+    });
 });
 
 describe('spec', function () {
@@ -69,6 +107,16 @@ describe('spec', function () {
             description: '',
             default: false,
             examples: [false]
+        });
+    });
+    it('should spec null', function () {
+        expect(spec(null, {$id: '#/nullObject'})).to.deep.equal({
+            title: 'An object value',
+            description: '',
+            required: [],
+            properties: {},
+            $id: '#/nullObject',
+            type: 'object'
         });
     });
     it('should spec string', function () {
@@ -90,6 +138,16 @@ describe('spec', function () {
             description: '',
             default: 0,
             examples: [1.67]
+        });
+    });
+    it('should spec integer', function () {
+        expect(spec(16, {$id: '#/age'})).to.deep.equal({
+            $id: '#/age',
+            type: 'integer',
+            title: 'An integer value',
+            description: '',
+            default: 0,
+            examples: [16]
         });
     });
     it('should spec array', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 import {typeOf, infer, spec} from '../src/index.js';
-import {expect} from 'chai';
+// import {expect} from 'chai';
+import pkg from 'chai'; const { expect } = pkg;
 
 describe('typeOf', function () {
     it('should detect boolean', function () {
@@ -58,7 +59,7 @@ describe('infer', function () {
             }
         });
     });
-    it('should infer object ', function () {
+    it('should infer object that one of it\'s keys is null', function () {
         expect(infer({name: 'harttle', age: 16, hobbies: null}, {title: 'Harttle Schema'})).to.deep.equal({
             $schema: 'http://json-schema.org/draft-07/schema#',
             $id: 'http://example.org/root.json#',


### PR DESCRIPTION
This PR is not quite a fix, or a feature, but rather a suggestion
### What did this pull request do?
The schema generator will crash when trying to generate a schema for a JSON with a property-value null:
`{ "someKey": null }`. When generating the schema for a property with `null` as a value, treat it as Object with no keys. The result looks something like this:
`"k3": {
            "title": "An object value",
            "description": "",
            "required": [],
            "properties": {},
            "$id": "#/properties/k3",
            "type": "object"
        }`

### User Case Description
It is quite common to have JSON files where one of their property's values is `null`. It does not matter if the property was designed to describe numbers, strings, arrays or objects. It can still be `null` nevertheless.

### Considerations
I had two solutions in mind: to treat "null" as "type": null, and implement a new _specFor_ code section, or to to treat it as an _object_ still, and let the existing code do its thing (which it does).
Comparing to existing generators:
[json-s-generator](https://www.npmjs.com/package/json-s-generator) and [to-json-schema](https://www.npmjs.com/package/to-json-schemal) treat null as "type": "null". So does the excellent [jsonschema.net](https://jsonschema.net/home).

However, since the Javascript Spec itself states that the type of `null` is Object ([see here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description)), I actually thought it would be better to treat it this way. And I have at least one extra tool to think the same ([json-schema-generator](https://www.npmjs.com/package/json-schema-generator))

In the attached files, I have included some results for generating schema for the following object:
`{
    "k1": "v1",
    "k2": [1,2,3],
    "k3": null
}`

[jsg07 samples.zip](https://github.com/harttle/json-schema-generator/files/5012529/jsg07.samples.zip)

